### PR TITLE
Add support to ingest from a multiple files or dirs.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2016 Uncharted Software Inc.
+Copyright © 2016-2017 Uncharted Software Inc.
 
 Property of Uncharted™, formerly Oculus Info Inc.
 http://uncharted.software/

--- a/README.md
+++ b/README.md
@@ -128,8 +128,17 @@ func main() {
 
 	// Create a filesystem input type
 	input := file.NewInput(
-		"/path/to/data",
-		[ "files", "or", "dirs", "to", "exclude" ])
+		[
+			"/path/to/file",
+			"/path/to/dir",
+		],
+		[
+			"files",
+			"or",
+			"dirs",
+			"to",
+			"exclude",
+		])
 
 	// Create the elasticsearch client
 	client, err := elastic.NewClient(

--- a/hdfs/client.go
+++ b/hdfs/client.go
@@ -78,3 +78,8 @@ func (c *Client) Close() error {
 func (c *Client) ReadDir(dirname string) ([]os.FileInfo, error) {
 	return c.conn.ReadDir(dirname)
 }
+
+// Stat returns an os.FileInfo describing the named file or directory.
+func (c *Client) Stat(path string) (os.FileInfo, error) {
+	return c.conn.Stat(path)
+}

--- a/input.go
+++ b/input.go
@@ -20,11 +20,11 @@ func NewElasticInput(client elastic.Client, index string, scanSize int) (Input, 
 }
 
 // NewFileInput instantiates a new instance of a file input.
-func NewFileInput(path string, excludes []string) (Input, error) {
-	return file.NewInput(path, excludes)
+func NewFileInput(paths []string, excludes []string) (Input, error) {
+	return file.NewInput(paths, excludes)
 }
 
 // NewHDFSInput instantiates a new instance of a hdfs input.
-func NewHDFSInput(client hdfs.Client, path string, excludes []string) (Input, error) {
-	return hdfs.NewInput(client, path, excludes)
+func NewHDFSInput(client hdfs.Client, paths []string, excludes []string) (Input, error) {
+	return hdfs.NewInput(client, paths, excludes)
 }

--- a/input/hdfs/input.go
+++ b/input/hdfs/input.go
@@ -30,32 +30,48 @@ type Source struct {
 }
 
 func getInfo(client Client, path string, excludes []string) ([]*Source, error) {
-	// read target files
-	files, err := client.ReadDir(path)
+	// get info on path
+	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
 	}
 	// data to populate
 	var sources []*Source
-	// for each file / dir
-	for _, file := range files {
-		if util.IsValidDir(file, excludes) {
-			// depth-first traversal into sub directories
-			children, err := getInfo(client, path+"/"+file.Name(), excludes)
-			if err != nil {
-				return nil, err
+	// check if dir
+	if !info.IsDir() {
+		// is file
+		// add source
+		sources = append(sources, &Source{
+			file: info,
+			path: path,
+		})
+	} else {
+		// is directory
+		// read target files
+		files, err := client.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+		// for each file / dir
+		for _, file := range files {
+			if util.IsValidDir(file, excludes) {
+				// depth-first traversal into sub directories
+				children, err := getInfo(client, path+"/"+file.Name(), excludes)
+				if err != nil {
+					return nil, err
+				}
+				sources = append(sources, children...)
+			} else if util.IsValidFile(file, excludes) {
+				// add source
+				sources = append(sources, &Source{
+					file: file,
+					path: path,
+				})
 			}
-			sources = append(sources, children...)
-		} else if util.IsValidFile(file, excludes) {
-			// add source
-			sources = append(sources, &Source{
-				file: file,
-				path: path,
-			})
 		}
 	}
 	// return ingest info
-	return sources[0:], nil
+	return sources, nil
 }
 
 // NewInput instantiates a new instance of a file input.

--- a/threshold/threshold.go
+++ b/threshold/threshold.go
@@ -49,13 +49,13 @@ func AddSuccess() {
 
 // Errs returns all ingestion errors.
 func Errs() []error {
-	return errs[0:]
+	return errs
 }
 
 // SampleErrs returns an N sized sample of errors.
 func SampleErrs(n int) []error {
 	if len(errs) < n {
-		return errs[0:]
+		return errs
 	}
 	stride := float64(len(errs)) / float64(n)
 	samples := make([]error, n)
@@ -63,5 +63,5 @@ func SampleErrs(n int) []error {
 		index := int(math.Floor(float64(i) * stride))
 		samples[i] = errs[index]
 	}
-	return samples[0:]
+	return samples
 }


### PR DESCRIPTION
Previously `hdfs.Input` and `file.Input` would fail if given a path to a file. 

This adds support to handle an array of both files and directories.