### PR TITLE
setting the blocks.write attribute

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,4 +9,5 @@ type Client interface {
 	PutMapping(string, string, string) error
 	EnableReplicas(string, int) error
 	SetReadOnly(string, bool) error
+	SetBlockWrite(string, bool) error
 }

--- a/elastic/v2/client.go
+++ b/elastic/v2/client.go
@@ -244,3 +244,16 @@ func (c *Client) SetReadOnly(index string, readOnly bool) error {
 	}
 	return nil
 }
+
+// SetBlockWrite sets the block.write status of an index
+func (c *Client) SetBlockWrite(index string, blockWrite bool) error {
+	body := fmt.Sprintf("{\"index\":{\"blocks\":{\"write\": %v}}}", blockWrite)
+	res, err := c.client.IndexPutSettings(index).BodyString(body).Do()
+	if err != nil {
+		return fmt.Errorf("Error occurred while trying to set block_write attribute of the index: %v", err)
+	}
+	if !res.Acknowledged {
+		return fmt.Errorf("Setting block write attribute request not acknowledged for index `%s`", index)
+	}
+	return nil
+}

--- a/elastic/v5/client.go
+++ b/elastic/v5/client.go
@@ -253,3 +253,16 @@ func (c *Client) SetReadOnly(index string, readOnly bool) error {
 	}
 	return nil
 }
+
+// SetBlockWrite sets the block-write status of an index
+func (c *Client) SetBlockWrite(index string, blockWrite bool) error {
+	body := fmt.Sprintf("{\"index\":{\"blocks\":{\"write\": %v}}}", blockWrite)
+	res, err := c.client.IndexPutSettings(index).BodyString(body).Do(context.Background())
+	if err != nil {
+		return fmt.Errorf("Error occurred while trying to set block_write attribute of the index: %v", err)
+	}
+	if !res.Acknowledged {
+		return fmt.Errorf("Setting block write attribute request not acknowledged for index `%s`", index)
+	}
+	return nil
+}

--- a/elastic/v7/client.go
+++ b/elastic/v7/client.go
@@ -260,3 +260,16 @@ func (c *Client) SetReadOnly(index string, readOnly bool) error {
 	}
 	return nil
 }
+
+// SetBlockWrite sets the block-write status of an index
+func (c *Client) SetBlockWrite(index string, blockWrite bool) error {
+	body := fmt.Sprintf("{\"index\":{\"blocks\":{\"write\": %v}}}", blockWrite)
+	res, err := c.client.IndexPutSettings(index).BodyString(body).Do(context.Background())
+	if err != nil {
+		return fmt.Errorf("Error occurred while trying to set block_write attribute of the index: %v", err)
+	}
+	if !res.Acknowledged {
+		return fmt.Errorf("Setting block write attribute request not acknowledged for index `%s`", index)
+	}
+	return nil
+}

--- a/ingestor.go
+++ b/ingestor.go
@@ -31,6 +31,7 @@ const (
 	defaultScanBufferSize       = 1024 * 1024 * 2
 	defaultUpdateMapping        = false
 	defaultReadOnly             = false
+	defaultBlockWrite           = false
 )
 
 // Ingestor is an Elasticsearch ingestor client. Create one by calling
@@ -50,6 +51,7 @@ type Ingestor struct {
 	scanBufferSize       int
 	updateMapping        bool
 	readOnly             bool
+	blockWrite           bool
 	bulkSizeOptimiser    Optimiser
 	mutex                *sync.RWMutex
 	callbackWG           *sync.WaitGroup
@@ -69,6 +71,7 @@ func NewIngestor(options ...IngestorOptionFunc) (*Ingestor, error) {
 		scanBufferSize:       defaultScanBufferSize,
 		updateMapping:        defaultUpdateMapping,
 		readOnly:             defaultReadOnly,
+		blockWrite:           defaultBlockWrite,
 		mutex:                &sync.RWMutex{},
 		callbackWG:           &sync.WaitGroup{},
 	}
@@ -223,6 +226,11 @@ func (i *Ingestor) Ingest() error {
 
 	// set the index as read-only (if necessary)
 	if err := i.client.SetReadOnly(i.index, i.readOnly); err != nil {
+		return err
+	}
+
+	// set the index as block write (if necessary)
+	if err := i.client.SetBlockWrite(i.index, i.blockWrite); err != nil {
 		return err
 	}
 

--- a/options.go
+++ b/options.go
@@ -126,10 +126,21 @@ func SetUpdateMapping(updateMapping bool) IngestorOptionFunc {
 	}
 }
 
-// SetReadOnly sets whether or not to set an index to read only after ingestion
+// SetReadOnly sets whether or not to set an index to read only after ingestion.
+// However, you will be unable to clone the index, since cloning alters metadata.
+// If you want to be able to clone your index consider `SetBlockWrite(true)`
 func SetReadOnly(readOnly bool) IngestorOptionFunc {
 	return func(i *Ingestor) error {
 		i.readOnly = readOnly
+		return nil
+	}
+}
+
+// SetBlockWrite sets whether we are able to set the body of the index to read only.
+// You will still be able to alter the metadata of an index if you use this setting.
+func SetBlockWrite(blockWrite bool) IngestorOptionFunc {
+	return func(i *Ingestor) error {
+		i.blockWrite = blockWrite
 		return nil
 	}
 }


### PR DESCRIPTION
The `blocks.read_only` prohibits us from cloning the `read_only` index. Setting `blocks.write` will allow us to make the body read only while allowing us to modify the metadata of the index, allowing us to clone a read only index.