### PR TITLE
Ensure callback waitgroup is decremented on error.

### DIFF
--- a/ingestor.go
+++ b/ingestor.go
@@ -266,9 +266,11 @@ func getReader(reader io.Reader, compression string) (io.Reader, error) {
 func (i *Ingestor) createProgressCallback(bytes, docs int64) equalizer.CallbackFunc {
 	// increment callback waitgroup
 	i.callbackWG.Add(1)
-	return func() {
-		// update and print current progress
-		progress.UpdateProgress(bytes, docs)
+	return func(err error) {
+		if err == nil {
+			// update and print current progress if no error
+			progress.UpdateProgress(bytes, docs)
+		}
 		// decrement waitgroup
 		i.callbackWG.Done()
 	}

--- a/ingestor.go
+++ b/ingestor.go
@@ -209,12 +209,18 @@ func (i *Ingestor) Ingest() error {
 	// wait until all callbacks executed
 	i.callbackWG.Wait()
 
+	// close the backpressure equalizer
+	errs := equalizer.Close()
+	if len(errs) > 0 {
+		// return the first error
+		progress.EndProgress()
+		progress.PrintFailure()
+		return errs[0]
+	}
+
 	// success
 	progress.EndProgress()
 	progress.PrintSuccess()
-
-	// close the backpressure equalizer
-	equalizer.Close()
 
 	// enable replication
 	if i.numReplicas > 0 {


### PR DESCRIPTION
Callbacks increment a waitgroup, but were never executed to decrement it on an error. This ensures they are decremented without pushing the progress.